### PR TITLE
Fix `make -f Makefile.cvs` build error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -645,7 +645,7 @@ AC_CONFIG_FILES([Makefile
                  data/drivers/posix/Makefile
                  data/drivers/posix/generic_pcsc/Makefile
                  data/drivers/win32/Makefile
-                 data/drivers/win32/cyberjack_ctapi/Makefile
+                 data/drivers/win32/cyberjack_pcsc/Makefile
                  data/drivers/win32/generic_pcsc/Makefile
                  doc/Makefile
                  po/Makefile

--- a/data/drivers/win32/Makefile.am
+++ b/data/drivers/win32/Makefile.am
@@ -1,4 +1,4 @@
 SUBDIRS=\
  generic_pcsc \
- cyberjack_ctapi
+ cyberjack_pcsc
 


### PR DESCRIPTION
configure.ac/Makefile.am still referenced a directory that has been
renamed in 3025243313abc3b38a7095531ce868ddf1f369a0.

```
$ make -f Makefile.cvs
libtoolize -f --automake
aclocal  -I m4
autoheader
automake --add-missing
configure.ac:91: warning: AM_INIT_AUTOMAKE: two- and three-arguments forms are deprecated.  For more info, see:
configure.ac:91: https://www.gnu.org/software/automake/manual/automake.html#Modernize-AM_005fINIT_005fAUTOMAKE-invocation
configure.ac:143: installing './compile'
configure.ac:91: installing './missing'
Makefile.am:108: warning: shell cat $(srcdir: non-POSIX variable name
Makefile.am:108: (probably a GNU make extension)
Makefile.am:109: warning: shell cat $(srcdir: non-POSIX variable name
Makefile.am:109: (probably a GNU make extension)
Makefile.am:110: warning: shell cat $(srcdir: non-POSIX variable name
Makefile.am:110: (probably a GNU make extension)
Makefile.am:134: warning: basename $(notdir $(shell ls $(srcdir: non-POSIX variable name
Makefile.am:134: (probably a GNU make extension)
Makefile.am:141: warning: foreach lang,$(ALL_LINGUAS: non-POSIX variable name
Makefile.am:141: (probably a GNU make extension)
Makefile.am:145: warning: foreach lang,$(ALL_LINGUAS: non-POSIX variable name
Makefile.am:145: (probably a GNU make extension)
Makefile.am:146: warning: foreach lang,$(ALL_LINGUAS: non-POSIX variable name
Makefile.am:146: (probably a GNU make extension)
configure.ac:639: error: required file 'data/drivers/win32/cyberjack_ctapi/Makefile.in' not found
data/drivers/win32/Makefile.am:1: error: required directory data/drivers/win32/cyberjack_ctapi does not exist
src/ct/chiptanusb/Makefile.am: installing './depcomp'
make: *** [Makefile.cvs:47: all] Error 1
```