### PR TITLE
Fix memory leaks in card.c/card_files.c

### DIFF
--- a/src/libchipcard/base/card.c
+++ b/src/libchipcard/base/card.c
@@ -177,6 +177,8 @@ void LC_Card_free(LC_CARD *cd)
       free(cd->cardType);
       free(cd->lastResult);
       free(cd->lastText);
+      free(cd->readerType);
+      free(cd->driverType);
       GWEN_StringList_free(cd->cardTypes);
       GWEN_Buffer_free(cd->atr);
       GWEN_DB_Group_free(cd->dbCommandCache);

--- a/src/libchipcard/base/card_files.c
+++ b/src/libchipcard/base/card_files.c
@@ -125,6 +125,7 @@ int LC_Card_SelectDf(LC_CARD *card, const char *fname)
                         "fileId",
                         GWEN_Buffer_GetStart(buf),
                         GWEN_Buffer_GetUsedBytes(buf));
+    GWEN_Buffer_free(buf);
     cmd="SelectDFL";
 
   }
@@ -201,6 +202,7 @@ int LC_Card_SelectEf(LC_CARD *card, const char *fname)
                         "fileId",
                         GWEN_Buffer_GetStart(buf),
                         GWEN_Buffer_GetUsedBytes(buf));
+    GWEN_Buffer_free(buf);
     cmd="SelectEFL";
 
   }
@@ -268,6 +270,7 @@ int LC_Card_SelectEfById(LC_CARD *card, const int  sid)
                         "fileId",
                         GWEN_Buffer_GetStart(buf),
                         GWEN_Buffer_GetUsedBytes(buf));
+    GWEN_Buffer_free(buf);
     cmd="SelectEFL";
 
   }


### PR DESCRIPTION
- the LC_CARD struct members readerType and driverType are not freed in
  LC_Card_free()
- LC_Card_Select{Df,Ef,EfById}() leaks a GWEN_BUFFER local to the function